### PR TITLE
Use local logos and add quests section

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       </nav>
       <div class="hero">
         <h1>Farid&nbsp;Rezaei</h1>
-        <p class="subtitle">Software Engineer</p>
+        <p class="subtitle">Data Analyst</p>
         <p>
           Passionate about building scalable software and delivering solutions.
         </p>
@@ -64,7 +64,7 @@
         <h2>Experience</h2>
         <div class="experience-item">
           <img
-            src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Delivery_Hero_logo.svg/512px-Delivery_Hero_logo.svg.png"
+            src="src/logos/delivery-hero.svg"
             alt="Delivery Hero logo"
             class="company-logo"
           />
@@ -112,7 +112,7 @@
         </div>
         <div class="experience-item">
           <img
-            src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Foodpanda_logo.svg/512px-Foodpanda_logo.svg.png"
+            src="src/logos/foodpanda.svg"
             alt="foodpanda logo"
             class="company-logo"
           />
@@ -164,7 +164,7 @@
         </div>
         <div class="experience-item">
           <img
-            src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Snapp%21_logo.svg/512px-Snapp%21_logo.svg.png"
+            src="src/logos/snapp.svg"
             alt="Snapp! logo"
             class="company-logo"
           />
@@ -204,7 +204,7 @@
         </div>
         <div class="experience-item">
           <img
-            src="https://sabacell.com/favicon.ico"
+            src="src/logos/sabacell.svg"
             alt="SabaCell logo"
             class="company-logo"
           />
@@ -247,7 +247,7 @@
         <h2>Volunteering</h2>
         <div class="volunteer-item">
           <img
-            src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/Openstreetmap_logo.svg/512px-Openstreetmap_logo.svg.png"
+            src="src/logos/openstreetmap.svg"
             alt="OpenStreetMap logo"
             class="volunteer-logo"
           />
@@ -272,7 +272,7 @@
         </div>
         <div class="volunteer-item">
           <img
-            src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Iranian_Red_Crescent_Society_logo.svg/512px-Iranian_Red_Crescent_Society_logo.svg.png"
+            src="src/logos/red-crescent.svg"
             alt="Red Crescent Society of the Islamic Republic of Iran logo"
             class="volunteer-logo"
           />
@@ -296,7 +296,7 @@
         </div>
         <div class="volunteer-item">
           <img
-            src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Iranian_Red_Crescent_Society_logo.svg/512px-Iranian_Red_Crescent_Society_logo.svg.png"
+            src="src/logos/red-crescent.svg"
             alt="Red Crescent Society of the Islamic Republic of Iran logo"
             class="volunteer-logo"
           />
@@ -324,7 +324,7 @@
         <h2>Education</h2>
         <div class="education-item">
           <img
-            src="https://upload.wikimedia.org/wikipedia/en/thumb/f/f5/Sharif_University_of_Technology_logo.svg/512px-Sharif_University_of_Technology_logo.svg.png"
+            src="src/logos/sharif.svg"
             alt="Sharif University of Technology logo"
             class="edu-logo"
           />
@@ -341,7 +341,7 @@
         </div>
         <div class="education-item">
           <img
-            src="https://upload.wikimedia.org/wikipedia/en/thumb/0/0d/University_of_Kashan_Logo.svg/512px-University_of_Kashan_Logo.svg.png"
+            src="src/logos/kashan.svg"
             alt="University of Kashan logo"
             class="edu-logo"
           />
@@ -364,6 +364,32 @@
           <li>SQL</li>
           <li>Git</li>
         </ul>
+      </section>
+      <!-- Quests in Progress section -->
+      <section id="quests" class="section">
+        <h2>Quests in Progress</h2>
+        <div class="quest-item">
+          <h3>German Language</h3>
+          <div class="language-progress">
+            <span class="level-label">0</span>
+            <span class="dot completed" title="A1"></span>
+            <span class="dot current" title="A2"></span>
+            <span class="dot" title="B1"></span>
+            <span class="dot" title="B2"></span>
+            <span class="dot" title="C1"></span>
+            <span class="dot" title="C2"></span>
+          </div>
+        </div>
+        <div class="quest-item">
+          <h3>
+            An attempt to build some reports on my chess games
+            <img
+              src="src/logos/under-construction.svg"
+              alt="under construction icon"
+              class="quest-icon"
+            />
+          </h3>
+        </div>
       </section>
       <!-- Contact section -->
       <section id="contact" class="section contact-section">

--- a/src/logos/delivery-hero.svg
+++ b/src/logos/delivery-hero.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ff3a44"/>
+  <text x="50%" y="50%" font-size="40" fill="#fff" text-anchor="middle" dominant-baseline="middle">DH</text>
+</svg>

--- a/src/logos/foodpanda.svg
+++ b/src/logos/foodpanda.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ff2d55"/>
+  <text x="50%" y="50%" font-size="40" fill="#fff" text-anchor="middle" dominant-baseline="middle">FP</text>
+</svg>

--- a/src/logos/kashan.svg
+++ b/src/logos/kashan.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#006400"/>
+  <text x="50%" y="50%" font-size="24" fill="#fff" text-anchor="middle" dominant-baseline="middle">UK</text>
+</svg>

--- a/src/logos/openstreetmap.svg
+++ b/src/logos/openstreetmap.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#8fbc8f"/>
+  <text x="50%" y="50%" font-size="24" fill="#fff" text-anchor="middle" dominant-baseline="middle">OSM</text>
+</svg>

--- a/src/logos/red-crescent.svg
+++ b/src/logos/red-crescent.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#e60000"/>
+  <text x="50%" y="50%" font-size="24" fill="#fff" text-anchor="middle" dominant-baseline="middle">RCS</text>
+</svg>

--- a/src/logos/sabacell.svg
+++ b/src/logos/sabacell.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#0033a0"/>
+  <text x="50%" y="50%" font-size="32" fill="#fff" text-anchor="middle" dominant-baseline="middle">SC</text>
+</svg>

--- a/src/logos/sharif.svg
+++ b/src/logos/sharif.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#003d99"/>
+  <text x="50%" y="50%" font-size="24" fill="#fff" text-anchor="middle" dominant-baseline="middle">SUT</text>
+</svg>

--- a/src/logos/snapp.svg
+++ b/src/logos/snapp.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#00bf6f"/>
+  <text x="50%" y="50%" font-size="40" fill="#fff" text-anchor="middle" dominant-baseline="middle">S</text>
+</svg>

--- a/src/logos/under-construction.svg
+++ b/src/logos/under-construction.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#fdd835"/>
+  <text x="50%" y="50%" font-size="40" fill="#000" text-anchor="middle" dominant-baseline="middle">🚧</text>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -136,6 +136,40 @@ a:hover {
   margin: 0.5rem 0;
 }
 
+/* Quests in Progress */
+.quest-item {
+  margin-bottom: 1.5rem;
+}
+.language-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+.language-progress .level-label {
+  font-size: 0.9rem;
+  color: #b3b3b3;
+}
+.language-progress .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: #555;
+}
+.language-progress .dot.completed,
+.language-progress .dot.current {
+  background-color: #64b5f6;
+}
+.language-progress .dot.current {
+  box-shadow: 0 0 0 2px #ffffff;
+}
+.quest-icon {
+  width: 24px;
+  height: 24px;
+  vertical-align: middle;
+  margin-left: 0.5rem;
+}
+
 /* Footer */
 footer {
   text-align: center;


### PR DESCRIPTION
## Summary
- Replace remote image sources with local SVG logo placeholders
- Update hero subtitle to "Data Analyst"
- Introduce "Quests in Progress" with German language dots and under-construction chess reports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dc8f865048326bb5d94059497c195